### PR TITLE
Workaround for missing namespace defintion VulkanMemoryAllocator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,17 @@ find_package(Vulkan REQUIRED)
 
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/VulkanMemoryAllocator/CMakeLists.txt)
     add_subdirectory(VulkanMemoryAllocator)
+    add_library(VulkanMemoryAllocator::VulkanMemoryAllocator ALIAS VulkanMemoryAllocator)
+    install(
+            TARGETS VulkanMemoryAllocator
+            EXPORT VulkanMemoryAllocator-Targets
+    )
+    install(
+            EXPORT VulkanMemoryAllocator-Targets
+            FILE VulkanMemoryAllocator-Targets.cmake
+            NAMESPACE VulkanMemoryAllocator::
+            DESTINATION lib/cmake/VulkanMemoryAllocator
+    )
 else()
     find_package(VulkanMemoryAllocator REQUIRED)
 endif()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VulkanMemoryAllocator-Hpp <!--VER-->3.1.0-development<!--/VER-->
+# VulkanMemoryAllocator-Hpp <!--VER-->3.0.1 (2022-05-26)<!--/VER-->
 
 ### Supports Vulkan <!--VK-->1.3<!--/VK-->
 

--- a/include/vk_mem_alloc_funcs.hpp
+++ b/include/vk_mem_alloc_funcs.hpp
@@ -769,24 +769,6 @@ namespace VMA_HPP_NAMESPACE {
   }
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-  VULKAN_HPP_INLINE typename VULKAN_HPP_NAMESPACE::ResultValueType<VULKAN_HPP_NAMESPACE::Buffer>::type Allocator::createAliasingBuffer2(Allocation allocation,
-                                                                                                                                        VULKAN_HPP_NAMESPACE::DeviceSize allocationLocalOffset,
-                                                                                                                                        const VULKAN_HPP_NAMESPACE::BufferCreateInfo& bufferCreateInfo) const {
-    VULKAN_HPP_NAMESPACE::Buffer buffer;
-    VULKAN_HPP_NAMESPACE::Result result = static_cast<VULKAN_HPP_NAMESPACE::Result>( vmaCreateAliasingBuffer2(m_allocator, static_cast<VmaAllocation>(allocation), static_cast<VkDeviceSize>(allocationLocalOffset), reinterpret_cast<const VkBufferCreateInfo*>(&bufferCreateInfo), reinterpret_cast<VkBuffer*>(&buffer)) );
-    resultCheck(result, VMA_HPP_NAMESPACE_STRING "::Allocator::createAliasingBuffer2");
-    return createResultValueType(result, buffer);
-  }
-#endif
-  VULKAN_HPP_INLINE VULKAN_HPP_NAMESPACE::Result Allocator::createAliasingBuffer2(Allocation allocation,
-                                                                                  VULKAN_HPP_NAMESPACE::DeviceSize allocationLocalOffset,
-                                                                                  const VULKAN_HPP_NAMESPACE::BufferCreateInfo* bufferCreateInfo,
-                                                                                  VULKAN_HPP_NAMESPACE::Buffer* buffer) const {
-    VULKAN_HPP_NAMESPACE::Result result = static_cast<VULKAN_HPP_NAMESPACE::Result>( vmaCreateAliasingBuffer2(m_allocator, static_cast<VmaAllocation>(allocation), static_cast<VkDeviceSize>(allocationLocalOffset), reinterpret_cast<const VkBufferCreateInfo*>(bufferCreateInfo), reinterpret_cast<VkBuffer*>(buffer)) );
-    return result;
-  }
-
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Allocator::destroyBuffer(VULKAN_HPP_NAMESPACE::Buffer buffer,
                                                   Allocation allocation) const {
     vmaDestroyBuffer(m_allocator, static_cast<VkBuffer>(buffer), static_cast<VmaAllocation>(allocation));
@@ -844,24 +826,6 @@ namespace VMA_HPP_NAMESPACE {
                                                                                 const VULKAN_HPP_NAMESPACE::ImageCreateInfo* imageCreateInfo,
                                                                                 VULKAN_HPP_NAMESPACE::Image* image) const {
     VULKAN_HPP_NAMESPACE::Result result = static_cast<VULKAN_HPP_NAMESPACE::Result>( vmaCreateAliasingImage(m_allocator, static_cast<VmaAllocation>(allocation), reinterpret_cast<const VkImageCreateInfo*>(imageCreateInfo), reinterpret_cast<VkImage*>(image)) );
-    return result;
-  }
-
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-  VULKAN_HPP_INLINE typename VULKAN_HPP_NAMESPACE::ResultValueType<VULKAN_HPP_NAMESPACE::Image>::type Allocator::createAliasingImage2(Allocation allocation,
-                                                                                                                                      VULKAN_HPP_NAMESPACE::DeviceSize allocationLocalOffset,
-                                                                                                                                      const VULKAN_HPP_NAMESPACE::ImageCreateInfo& imageCreateInfo) const {
-    VULKAN_HPP_NAMESPACE::Image image;
-    VULKAN_HPP_NAMESPACE::Result result = static_cast<VULKAN_HPP_NAMESPACE::Result>( vmaCreateAliasingImage2(m_allocator, static_cast<VmaAllocation>(allocation), static_cast<VkDeviceSize>(allocationLocalOffset), reinterpret_cast<const VkImageCreateInfo*>(&imageCreateInfo), reinterpret_cast<VkImage*>(&image)) );
-    resultCheck(result, VMA_HPP_NAMESPACE_STRING "::Allocator::createAliasingImage2");
-    return createResultValueType(result, image);
-  }
-#endif
-  VULKAN_HPP_INLINE VULKAN_HPP_NAMESPACE::Result Allocator::createAliasingImage2(Allocation allocation,
-                                                                                 VULKAN_HPP_NAMESPACE::DeviceSize allocationLocalOffset,
-                                                                                 const VULKAN_HPP_NAMESPACE::ImageCreateInfo* imageCreateInfo,
-                                                                                 VULKAN_HPP_NAMESPACE::Image* image) const {
-    VULKAN_HPP_NAMESPACE::Result result = static_cast<VULKAN_HPP_NAMESPACE::Result>( vmaCreateAliasingImage2(m_allocator, static_cast<VmaAllocation>(allocation), static_cast<VkDeviceSize>(allocationLocalOffset), reinterpret_cast<const VkImageCreateInfo*>(imageCreateInfo), reinterpret_cast<VkImage*>(image)) );
     return result;
   }
 

--- a/include/vk_mem_alloc_handles.hpp
+++ b/include/vk_mem_alloc_handles.hpp
@@ -650,16 +650,6 @@ namespace VMA_HPP_NAMESPACE {
                                                                            VULKAN_HPP_NAMESPACE::Buffer* buffer) const;
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    VULKAN_HPP_NODISCARD_WHEN_NO_EXCEPTIONS typename VULKAN_HPP_NAMESPACE::ResultValueType<VULKAN_HPP_NAMESPACE::Buffer>::type createAliasingBuffer2(Allocation allocation,
-                                                                                                                                                     VULKAN_HPP_NAMESPACE::DeviceSize allocationLocalOffset,
-                                                                                                                                                     const VULKAN_HPP_NAMESPACE::BufferCreateInfo& bufferCreateInfo) const;
-#endif
-    VULKAN_HPP_NODISCARD VULKAN_HPP_NAMESPACE::Result createAliasingBuffer2(Allocation allocation,
-                                                                            VULKAN_HPP_NAMESPACE::DeviceSize allocationLocalOffset,
-                                                                            const VULKAN_HPP_NAMESPACE::BufferCreateInfo* bufferCreateInfo,
-                                                                            VULKAN_HPP_NAMESPACE::Buffer* buffer) const;
-
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     void destroyBuffer(VULKAN_HPP_NAMESPACE::Buffer buffer,
                        Allocation allocation) const;
 #else
@@ -690,16 +680,6 @@ namespace VMA_HPP_NAMESPACE {
     VULKAN_HPP_NODISCARD VULKAN_HPP_NAMESPACE::Result createAliasingImage(Allocation allocation,
                                                                           const VULKAN_HPP_NAMESPACE::ImageCreateInfo* imageCreateInfo,
                                                                           VULKAN_HPP_NAMESPACE::Image* image) const;
-
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    VULKAN_HPP_NODISCARD_WHEN_NO_EXCEPTIONS typename VULKAN_HPP_NAMESPACE::ResultValueType<VULKAN_HPP_NAMESPACE::Image>::type createAliasingImage2(Allocation allocation,
-                                                                                                                                                   VULKAN_HPP_NAMESPACE::DeviceSize allocationLocalOffset,
-                                                                                                                                                   const VULKAN_HPP_NAMESPACE::ImageCreateInfo& imageCreateInfo) const;
-#endif
-    VULKAN_HPP_NODISCARD VULKAN_HPP_NAMESPACE::Result createAliasingImage2(Allocation allocation,
-                                                                           VULKAN_HPP_NAMESPACE::DeviceSize allocationLocalOffset,
-                                                                           const VULKAN_HPP_NAMESPACE::ImageCreateInfo* imageCreateInfo,
-                                                                           VULKAN_HPP_NAMESPACE::Image* image) const;
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     void destroyImage(VULKAN_HPP_NAMESPACE::Image image,

--- a/include/vk_mem_alloc_handles.hpp
+++ b/include/vk_mem_alloc_handles.hpp
@@ -644,16 +644,6 @@ namespace VMA_HPP_NAMESPACE {
                                                                            VULKAN_HPP_NAMESPACE::Buffer* buffer) const;
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    VULKAN_HPP_NODISCARD_WHEN_NO_EXCEPTIONS typename VULKAN_HPP_NAMESPACE::ResultValueType<VULKAN_HPP_NAMESPACE::Buffer>::type createAliasingBuffer2(Allocation allocation,
-                                                                                                                                                     VULKAN_HPP_NAMESPACE::DeviceSize allocationLocalOffset,
-                                                                                                                                                     const VULKAN_HPP_NAMESPACE::BufferCreateInfo& bufferCreateInfo) const;
-#endif
-    VULKAN_HPP_NODISCARD VULKAN_HPP_NAMESPACE::Result createAliasingBuffer2(Allocation allocation,
-                                                                            VULKAN_HPP_NAMESPACE::DeviceSize allocationLocalOffset,
-                                                                            const VULKAN_HPP_NAMESPACE::BufferCreateInfo* bufferCreateInfo,
-                                                                            VULKAN_HPP_NAMESPACE::Buffer* buffer) const;
-
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     void destroyBuffer(VULKAN_HPP_NAMESPACE::Buffer buffer,
                        Allocation allocation) const;
 #else
@@ -684,16 +674,6 @@ namespace VMA_HPP_NAMESPACE {
     VULKAN_HPP_NODISCARD VULKAN_HPP_NAMESPACE::Result createAliasingImage(Allocation allocation,
                                                                           const VULKAN_HPP_NAMESPACE::ImageCreateInfo* imageCreateInfo,
                                                                           VULKAN_HPP_NAMESPACE::Image* image) const;
-
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    VULKAN_HPP_NODISCARD_WHEN_NO_EXCEPTIONS typename VULKAN_HPP_NAMESPACE::ResultValueType<VULKAN_HPP_NAMESPACE::Image>::type createAliasingImage2(Allocation allocation,
-                                                                                                                                                   VULKAN_HPP_NAMESPACE::DeviceSize allocationLocalOffset,
-                                                                                                                                                   const VULKAN_HPP_NAMESPACE::ImageCreateInfo& imageCreateInfo) const;
-#endif
-    VULKAN_HPP_NODISCARD VULKAN_HPP_NAMESPACE::Result createAliasingImage2(Allocation allocation,
-                                                                           VULKAN_HPP_NAMESPACE::DeviceSize allocationLocalOffset,
-                                                                           const VULKAN_HPP_NAMESPACE::ImageCreateInfo* imageCreateInfo,
-                                                                           VULKAN_HPP_NAMESPACE::Image* image) const;
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     void destroyImage(VULKAN_HPP_NAMESPACE::Image image,


### PR DESCRIPTION
add alias VulkanMemoryAllocator
add install for VulkanMemoryAllocator